### PR TITLE
chore: reduce Turbo cache size and keep Storybook tests headless

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -10,8 +10,8 @@
     "clean": "rimraf storybook-static",
     "dev": "storybook dev -p 6006",
     "preview-storybook": "serve storybook-static",
-    "test": "vitest run --browser --project=storybook",
-    "test:cvrg": "vitest run --browser --coverage --project=storybook",
+    "test": "vitest run --project=storybook",
+    "test:cvrg": "vitest run --coverage --project=storybook",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -32,6 +32,10 @@
         "dist/**",
         ".next/**",
         "!.next/cache/**",
+        "!.next/dev/**",
+        "!.next/trace",
+        "!.next/trace-build",
+        "!.next/diagnostics/**",
         "storybook-static/**"
       ]
     },


### PR DESCRIPTION
## Summary
Prevent Turbo cache bloat by excluding Next.js dev-only `.next` artifacts from cached build outputs.
Ensure Storybook Vitest browser tests run headlessly so `pnpm refine` does not open a visible browser window.

## Related Issue
N/A

## Changes
- Added `!.next/dev/**` to root Turbo `build.outputs`.
- Added `!.next/trace`, `!.next/trace-build`, and `!.next/diagnostics/**` to root Turbo `build.outputs`.
- Updated `apps/storybook` test scripts to rely on project browser config (`headless: true`) instead of CLI `--browser` flag.
- Verified the full quality gate by running `pnpm refine` successfully.

## How to Test
1. Run `pnpm refine` from the repository root.
2. Confirm the Storybook test step runs without opening a visible browser window.
3. Run `pnpm turbo run build --filter=@repo/web... --cache-dir=.turbo/cache`.
4. Run `LATEST=$(ls -t .turbo/cache/*.tar.zst | head -1)` then `tar --zstd -tf "$LATEST" | rg '^apps/web/\.next/(dev|trace$|trace-build$|diagnostics/)'.` and confirm no matches.

## Screenshots (if UI changes)
N/A

## Checklist
- [x] I have tested these changes locally.
- [x] I added or updated tests when needed.
- [x] I updated documentation when needed.
- [x] This PR is ready for review.
