### PR TITLE
chore(release): defer cli publishing

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,6 +1,6 @@
 # Changesets
 
-This repository uses `@changesets/cli` to version the publishable packages in the monorepo. At the moment only `@o3osatoshi/ui` and `@o3osatoshi/toolkit` are released to npm; apps and other workspaces are ignored via `.changeset/config.json`.
+This repository uses `@changesets/cli` to version the publishable packages in the monorepo. At the moment `@o3osatoshi/config`, `@o3osatoshi/logging`, `@o3osatoshi/toolkit`, and `@o3osatoshi/ui` are released to npm; apps, the CLI, and other internal workspaces are ignored via `.changeset/config.json`.
 
 ## Recommended workflow (Codex + CI)
 
@@ -41,5 +41,5 @@ In exceptional cases where you want to run the release locally instead of via CI
   "@o3osatoshi/toolkit": patch
   ---
   ```
-  - Quote package names and list only packages that publish; private workspaces and ignored entries (`@repo/application`, `@repo/domain`, `@repo/prisma`, `@repo/eth`, `@repo/functions`, `@repo/storybook`, `@repo/web`) are skipped automatically.
+  - Quote package names and list only packages that publish; private workspaces and ignored entries (`@o3osatoshi/cli`, `@repo/application`, `@repo/domain`, `@repo/prisma`, `@repo/eth`, `@repo/functions`, `@repo/storybook`, `@repo/web`) are skipped automatically.
 - Let `pnpm release:version` delete processed files; do not remove them manually.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -19,7 +19,8 @@
     "@repo/interface",
     "@repo/prisma",
     "@repo/storybook",
-    "@repo/web"
+    "@repo/web",
+    "@o3osatoshi/cli"
   ],
   "linked": [],
   "updateInternalDependencies": "patch"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@o3osatoshi/cli",
   "version": "0.1.0",
-  "private": false,
+  "private": true,
   "description": "o3o command line interface",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary
Prevent the release workflow from publishing `@o3osatoshi/cli` while it is not ready for npm release.

## Related Issue
N/A

## Changes
- Mark `@o3osatoshi/cli` as private.
- Add `@o3osatoshi/cli` to the Changesets ignore list.
- Update the Changesets release notes to reflect the current publishable packages.

## How to Test
1. Run `pnpm exec changeset publish --dry-run`.
2. Confirm `@o3osatoshi/cli` is not listed in npm info or publish output.
3. Run `pnpm style:pkg:pure`.

## Screenshots (if UI changes)
N/A

## Checklist
- [x] I have tested these changes locally.
- [ ] I added or updated tests when needed.
- [x] I updated documentation when needed.
- [x] This PR is ready for review.
