### PR TITLE
chore(release): prepare package changesets

### DIFF
--- a/.changeset/config-release-prep.md
+++ b/.changeset/config-release-prep.md
@@ -1,0 +1,7 @@
+---
+"@o3osatoshi/config": minor
+---
+
+Add Vite `resolve` forwarding to the shared Vitest presets, so consumers can pass aliases and related resolve settings through `baseTestPreset`, `browserTestPreset`, and `storybookTestPreset`.
+
+Add ESLint guardrails against unsafe production type assertions, ignore temporary API Extractor JSON files, validate package metadata used by tsup external inference with Zod, and make the shared tsup bundle presets resolve synchronously.

--- a/.changeset/logging-release-prep.md
+++ b/.changeset/logging-release-prep.md
@@ -1,0 +1,7 @@
+---
+"@o3osatoshi/logging": minor
+---
+
+Expose `appendErrorAttributes` from the root logging entrypoint and broaden runtime transport error callbacks to accept unknown errors.
+
+Improve proxy and Next.js error attribute enrichment, update Axiom-related dependencies, and keep watch builds from cleaning output between rebuilds.

--- a/.changeset/toolkit-release-prep.md
+++ b/.changeset/toolkit-release-prep.md
@@ -1,0 +1,9 @@
+---
+"@o3osatoshi/toolkit": minor
+---
+
+Reorganize the public error, HTTP, JSON, and validation helpers around `RichError`.
+
+Add fetch response helpers, HTTP response builders/deserializers, URL redaction, rate-limit guards, object guards, typed `omitUndefined`, `trimTrailingSlash`, and abort signal resolution utilities.
+
+Consumers should migrate from `newError` to `newRichError`, from `parseWith`/`parseAsyncWith` to `makeSchemaParser`, from `encode`/`decode` to `serialize`/`deserialize`, and from `deserializeError` to `deserializeRichError`.

--- a/.changeset/ui-release-prep.md
+++ b/.changeset/ui-release-prep.md
@@ -1,0 +1,7 @@
+---
+"@o3osatoshi/ui": minor
+---
+
+Export `alertVariants` for downstream styling reuse.
+
+Refresh generated API reports after component parameter normalization and keep the UI package build configuration aligned with the shared tsup preset updates.


### PR DESCRIPTION
## Summary
Prepare package-specific Changesets for the next npm release.
Each publishable package has its own release note entry to avoid mixed changelog content.

## Related Issue
N/A

## Changes
- Add a minor changeset for `@o3osatoshi/config`.
- Add a minor changeset for `@o3osatoshi/logging`.
- Add minor changesets for `@o3osatoshi/toolkit` and `@o3osatoshi/ui`.
- Keep `@o3osatoshi/cli` out of the release set.

## How to Test
1. Run `pnpm exec changeset status --output=.changeset-status.json`.
2. Confirm the four publishable packages have package-specific minor releases.
3. Confirm `@o3osatoshi/cli` is listed as `type: none`.

## Screenshots (if UI changes)
N/A

## Checklist
- [x] I have tested these changes locally.
- [ ] I added or updated tests when needed.
- [x] I updated documentation when needed.
- [x] This PR is ready for review.
