### PR TITLE
fix(release): skip publish lifecycle scripts

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -62,13 +62,19 @@ jobs:
           UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
           UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
 
+      - name: Typecheck packages
+        run: pnpm turbo run typecheck --filter=@o3osatoshi/*
+
+      - name: Test packages
+        run: pnpm turbo run test --filter=@o3osatoshi/*
+
       - name: Creating .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
-            registry=https://registry.npmjs.org/
-            @o3osatoshi:registry=https://registry.npmjs.org/
-            always-auth=true
-            //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          registry=https://registry.npmjs.org/
+          @o3osatoshi:registry=https://registry.npmjs.org/
+          always-auth=true
+          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
           EOF
 
       - name: Create release PR or publish to npm
@@ -78,3 +84,5 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+          npm_config_ignore_scripts: "true"


### PR DESCRIPTION
## Summary
Fix the release workflow so npm publish does not rerun package lifecycle scripts during `changeset publish`.
Validation now runs explicitly before publish to avoid workspace `dist` races.

## Related Issue
N/A

## Changes
- Add explicit typecheck and test steps for `@o3osatoshi/*` packages before publishing.
- Disable npm lifecycle scripts only for the `changeset publish` step.
- Normalize the generated npm registry config formatting.

## How to Test
1. Validate workflow YAML parsing locally.
2. Run `git diff --check`.

## Screenshots (if UI changes)
N/A

## Checklist
- [x] I have tested these changes locally.
- [ ] I added or updated tests when needed.
- [ ] I updated documentation when needed.
- [x] This PR is ready for review.
