### PR TITLE
fix(release): remove duplicate ignore scripts env

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -85,4 +85,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_IGNORE_SCRIPTS: "true"
-          npm_config_ignore_scripts: "true"


### PR DESCRIPTION
## Summary
Fix the release workflow validation error caused by duplicate ignore-scripts environment keys.
Keep the uppercase npm config variable that disables lifecycle scripts during publish.

## Related Issue
N/A

## Changes
- Remove the lowercase duplicate `npm_config_ignore_scripts` environment key.
- Keep `NPM_CONFIG_IGNORE_SCRIPTS` for the Changesets publish step.
- Validate the workflow with actionlint and YAML parsing.

## How to Test
1. Run `pnpm dlx github-actionlint .github/workflows/release-packages.yml`.
2. Run `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-packages.yml')"`.

## Screenshots (if UI changes)
N/A

## Checklist
- [x] I have tested these changes locally.
- [ ] I added or updated tests when needed.
- [ ] I updated documentation when needed.
- [x] This PR is ready for review.
