### PR TITLE
fix(config): ignore coverage reports in eslint

### DIFF
--- a/.changeset/tidy-rules-dance.md
+++ b/.changeset/tidy-rules-dance.md
@@ -1,0 +1,5 @@
+---
+"@o3osatoshi/config": patch
+---
+
+Ignore coverage report output in shared ESLint config.

--- a/packages/config/eslint/config.mjs
+++ b/packages/config/eslint/config.mjs
@@ -11,6 +11,8 @@ export default [
       "**/.next/**",
       "**/.turbo/**",
       "**/.idea/**",
+      "**/.reports/**",
+      "**/coverage/**",
       "**/storybook-static/**",
       "**/temp/*.api.json",
     ],


### PR DESCRIPTION
## Summary
@o3osatoshi/config の共有 ESLint config で、coverage report 出力を lint 対象から除外します。

## Related Issue
N/A

## Changes
- `**/.reports/**` を共有 ESLint ignore に追加
- `**/coverage/**` を共有 ESLint ignore に追加
- `@o3osatoshi/config` の patch changeset を追加

## How to Test
1. `pnpm --filter @o3osatoshi/config typecheck`
2. `pnpm style:eslint:pure`

## Screenshots (if UI changes)
N/A

## Checklist
- [x] I have tested these changes locally.
- [x] I added or updated tests when needed.
- [x] I updated documentation when needed.
- [x] This PR is ready for review.
