### PR TITLE
feat(config): add node cli tsup preset

### DIFF
--- a/.changeset/node-cli-preset.md
+++ b/.changeset/node-cli-preset.md
@@ -1,0 +1,5 @@
+---
+"@o3osatoshi/config": minor
+---
+
+Add `nodeCliBundlePreset` for distributable Node.js CLI packages.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -37,14 +37,14 @@ Import presets from `@o3osatoshi/config/tsup` and export a config in `tsup.confi
 ```ts
 import { browserBundlePreset, publicDualBundlePreset, functionsBundlePreset, nodeCliBundlePreset } from "@o3osatoshi/config/tsup";
 
-// Browser/React library (ESM, externals React/Next). DTS optional via { dts: true }.
-export default browserBundlePreset({ entry: { index: "src/index.tsx" }, dts: true });
+// Browser/React library (ESM, externals React/Next). DTS enabled by default.
+export default browserBundlePreset({ entry: { index: "src/index.tsx" } });
 
 // Public library (ESM + CJS, with DTS).
 //    Default sourcemap: enabled in production/CI, disabled in dev.
 // export default publicDualBundlePreset({ entry: { index: "src/index.ts" } });
 
-// Firebase Functions (ESM, Node target). Adjust target per runtime.
+// Firebase Functions (CJS, Node target). Adjust target per runtime.
 // export default functionsBundlePreset({ entry: { index: "src/index.ts" } });
 
 // Node CLI (single-file executable bundles, no sourcemaps by default).
@@ -52,7 +52,7 @@ export default browserBundlePreset({ entry: { index: "src/index.tsx" }, dts: tru
 ```
 
 Notes
-- Externals are automatically derived from dependencies/peerDependencies of the nearest package.json. In addition, common UI libs are always externalized: `react`, `react-dom`, `next`.
+- `browserBundlePreset`, `publicDualBundlePreset`, and `functionsBundlePreset` automatically derive externals from dependencies/peerDependencies of the nearest package.json. In addition, common UI libs are always externalized: `react`, `react-dom`, `next`.
 - The browser bundle preset explicitly marks React/Next as externals for UI packages.
 - Each preset accepts standard `tsup` `Options` and sets sensible defaults.
 - `publicDualBundlePreset` enables `sourcemap` by default in production/CI; pass `{ sourcemap: false }` to disable.
@@ -60,9 +60,9 @@ Notes
 - You can pass through `env`, `banner`, `external`, `outDir`, and `onSuccess` as needed.
 
 Defaults (high-level)
-- `browserBundlePreset`: ESM, platform `browser`, React/Next external, `dts` off by default.
+- `browserBundlePreset`: ESM, platform `browser`, React/Next external, `dts` on by default.
 - `publicDualBundlePreset`: ESM + CJS, DTS on, `sourcemap` on in CI/prd, off in dev.
-- `functionsBundlePreset`: ESM, platform `node`, `target: node22`, sourcemap enabled.
+- `functionsBundlePreset`: CJS, platform `node`, `target: node22`, sourcemap enabled.
 - `nodeCliBundlePreset`: ESM, platform `node`, `target: node22`, DTS on, dependency bundling on, sourcemap disabled.
 
 ## tsconfig bases

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -2,7 +2,7 @@
 
 Shared configuration for my TypeScript projects.
 
-- tsup presets (browser/public-dual/functions)
+- tsup presets (browser/public-dual/functions/node-cli)
 - TypeScript tsconfig bases (base/node/browser/next/functions/storybook)
 - Biome shared configs (base, react, next)
 - ESLint flat config (perfectionist import/order rules)
@@ -35,7 +35,7 @@ Notes
 Import presets from `@o3osatoshi/config/tsup` and export a config in `tsup.config.mjs`.
 
 ```ts
-import { browserBundlePreset, publicDualBundlePreset, functionsBundlePreset } from "@o3osatoshi/config/tsup";
+import { browserBundlePreset, publicDualBundlePreset, functionsBundlePreset, nodeCliBundlePreset } from "@o3osatoshi/config/tsup";
 
 // Browser/React library (ESM, externals React/Next). DTS optional via { dts: true }.
 export default browserBundlePreset({ entry: { index: "src/index.tsx" }, dts: true });
@@ -46,6 +46,9 @@ export default browserBundlePreset({ entry: { index: "src/index.tsx" }, dts: tru
 
 // Firebase Functions (ESM, Node target). Adjust target per runtime.
 // export default functionsBundlePreset({ entry: { index: "src/index.ts" } });
+
+// Node CLI (single-file executable bundles, no sourcemaps by default).
+// export default nodeCliBundlePreset({ target: "node24" });
 ```
 
 Notes
@@ -53,12 +56,14 @@ Notes
 - The browser bundle preset explicitly marks React/Next as externals for UI packages.
 - Each preset accepts standard `tsup` `Options` and sets sensible defaults.
 - `publicDualBundlePreset` enables `sourcemap` by default in production/CI; pass `{ sourcemap: false }` to disable.
+- `nodeCliBundlePreset` bundles dependencies by default for portable CLI artifacts; pass `external` when a dependency must remain external.
 - You can pass through `env`, `banner`, `external`, `outDir`, and `onSuccess` as needed.
 
 Defaults (high-level)
 - `browserBundlePreset`: ESM, platform `browser`, React/Next external, `dts` off by default.
 - `publicDualBundlePreset`: ESM + CJS, DTS on, `sourcemap` on in CI/prd, off in dev.
 - `functionsBundlePreset`: ESM, platform `node`, `target: node22`, sourcemap enabled.
+- `nodeCliBundlePreset`: ESM, platform `node`, `target: node22`, DTS on, dependency bundling on, sourcemap disabled.
 
 ## tsconfig bases
 Pick a base that fits your project (TS 5+, `moduleResolution: "Bundler"`).

--- a/packages/config/etc/config.api.md
+++ b/packages/config/etc/config.api.md
@@ -22,6 +22,9 @@ export function browserTestPreset(opts?: Options): ViteUserConfig;
 export function functionsBundlePreset(opts?: Options_2): Options_2 | Options_2[] | ((overrideOptions: Options_2) => Options_2 | Options_2[] | Promise<Options_2 | Options_2[]>);
 
 // @public
+export function nodeCliBundlePreset(opts?: Options_2): Options_2 | Options_2[] | ((overrideOptions: Options_2) => Options_2 | Options_2[] | Promise<Options_2 | Options_2[]>);
+
+// @public
 export type Options = {
     plugins?: ViteUserConfig["plugins"];
     resolve?: ViteUserConfig["resolve"];

--- a/packages/config/src/tsup/index.ts
+++ b/packages/config/src/tsup/index.ts
@@ -84,6 +84,58 @@ export function functionsBundlePreset(opts: Options = {}) {
 }
 
 /**
+ * Creates a tsup configuration preset for distributable Node.js command-line tools.
+ *
+ * @remarks
+ * This preset is intended for packages that expose one or more executable
+ * `bin` entrypoints, optionally alongside a small programmatic API.
+ *
+ * The defaults optimize for predictable CLI distribution:
+ *
+ * - Emits ESM for modern Node.js runtimes.
+ * - Targets Node 22 by default, matching the package baseline.
+ * - Bundles dependencies into the output by default so release artifacts are
+ *   portable and do not depend on a sibling `node_modules` tree.
+ * - Disables code splitting so each executable entrypoint is a self-contained
+ *   file.
+ * - Disables source maps by default because CLI artifacts are often distributed
+ *   outside the source repository. Consumers can opt in with
+ *   `{ sourcemap: true }` for internal tooling or debuggable releases.
+ * - Emits declaration files by default so packages that also export a
+ *   programmatic API remain typed.
+ *
+ * Place a shebang such as `#!/usr/bin/env node` in the executable source file
+ * itself. tsup/esbuild preserves that shebang in the generated JavaScript
+ * without applying it to non-executable entries such as `src/index.ts`.
+ *
+ * By default, the preset builds `src/bin.ts` and also includes `src/index.ts`
+ * when that file exists. Pass `entry` to use different executable names or
+ * additional entrypoints.
+ *
+ * @param opts - Additional tsup options to override the preset defaults.
+ * @returns Resolved configuration object that can be passed directly to the tsup CLI.
+ * @public
+ */
+export function nodeCliBundlePreset(opts: Options = {}) {
+  return defineConfig({
+    treeshake: true,
+    ...opts,
+    bundle: opts.bundle ?? true,
+    clean: opts.clean ?? true,
+    dts: opts.dts ?? true,
+    entry: opts.entry ?? defaultNodeCliEntry(),
+    external: opts.external ?? [],
+    format: opts.format ?? ["esm"],
+    minify: opts.minify ?? false,
+    platform: opts.platform ?? "node",
+    skipNodeModulesBundle: opts.skipNodeModulesBundle ?? false,
+    sourcemap: opts.sourcemap ?? false,
+    splitting: opts.splitting ?? false,
+    target: opts.target ?? "node22",
+  });
+}
+
+/**
  * Creates a tsup configuration preset for public libraries that need dual ESM/CJS outputs.
  *
  * @remarks
@@ -152,6 +204,18 @@ function autoExternals(pkgDir = process.cwd()): string[] {
     console.warn(`Failed to read package.json from ${pkgDir}:`, error);
     return [];
   }
+}
+
+function defaultNodeCliEntry(): Record<string, string> {
+  const entry: Record<string, string> = {
+    bin: "src/bin.ts",
+  };
+
+  if (fs.existsSync(path.join(process.cwd(), "src/index.ts"))) {
+    entry["index"] = "src/index.ts";
+  }
+
+  return entry;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a shared Node CLI tsup preset to @o3osatoshi/config and documents the intended CLI defaults. Includes a changeset for the next config release.

## Related Issue
N/A

## Changes
- Added nodeCliBundlePreset for distributable Node.js CLI packages.
- Updated config README and API report for the new public export.
- Added a changeset marking @o3osatoshi/config for a minor release.

## How to Test
1. pnpm --filter @o3osatoshi/config typecheck
2. pnpm --filter @o3osatoshi/config build
3. pnpm --filter @o3osatoshi/config api:extract
4. pnpm style:pure

## Screenshots (if UI changes)
N/A

## Checklist
- [x] I have tested these changes locally.
- [x] I added or updated tests when needed.
- [x] I updated documentation when needed.
- [x] This PR is ready for review.
